### PR TITLE
README.md: Fix 404'd link to Pathfinding demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ TileProcess can be scripted to generate arbitrary output. So you can use it for 
 
 
 # PathFindingTest (moved!)
-PathFindingTest has now become an official [HaxeFlixel](http://github.com/HaxeFlixel) demo, [Heatmap Pathfinding](https://github.com/HaxeFlixel/flixel-demos/tree/dev/Flixel%20Features/HeatmapPathfinding)
+PathFindingTest has now become an official [HaxeFlixel](http://github.com/HaxeFlixel) demo, [Heatmap Pathfinding](https://github.com/HaxeFlixel/flixel-demos/tree/dev/Features/HeatmapPathfinding)
 
 (The version in this repo is now obsolete)
 


### PR DESCRIPTION
Hi,

I just stopped by this repo and was curious about the Heatmap Pathfinding demo. The link was not working when I clicked, but it looks like the folder was just renamed at the official flixel-demos repo.

This PR just deletes a few characters in that particular URL to make that link work again.